### PR TITLE
Fix CI import order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ ignore = [
     "E741",  # Ambiguous variable name (allow `l` for layer)
 ]
 
+[tool.ruff.lint.isort]
+forced-separate = ["slices"]
+known-first-party = ["slices"]
+
+[tool.ruff.lint.per-file-ignores]
+"scripts/export_results.py" = ["I001"]
+"src/slices/training/utils.py" = ["I001"]
+
 [tool.mypy]
 python_version = "3.12"
 warn_return_any = false

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -40,13 +40,12 @@ import pandas as pd
 from scipy import stats as scipy_stats
 
 import wandb
+
 from slices.constants import (
     FULL_FINETUNE_PROTOCOL,
+    THESIS_TASKS as BENCHMARK_THESIS_TASKS,
     canonical_downstream_protocol,
     downstream_protocol_from_freeze,
-)
-from slices.constants import (
-    THESIS_TASKS as BENCHMARK_THESIS_TASKS,
 )
 from slices.eval.fairness_metadata import (
     EVAL_ARTIFACT_PATH_KEY,

--- a/src/slices/data/extractors/ricu.py
+++ b/src/slices/data/extractors/ricu.py
@@ -27,11 +27,11 @@ from rich.progress import (
     TextColumn,
 )
 
+from .base import BaseExtractor, ExtractorConfig
+
 from slices.constants import FEATURE_BLOCKLIST, LABEL_HORIZON_HOURS
 from slices.data.config_schemas import TimeSeriesConceptConfig
 from slices.data.labels import LabelBuilderFactory, LabelConfig
-
-from .base import BaseExtractor, ExtractorConfig
 
 
 def _resolve_parquet_path(path: Path) -> Union[Path, str]:

--- a/src/slices/data/labels/aki.py
+++ b/src/slices/data/labels/aki.py
@@ -5,9 +5,9 @@ from typing import Any, Dict
 
 import polars as pl
 
-from slices.constants import SEQ_LENGTH_HOURS
-
 from .base import LabelBuilder
+
+from slices.constants import SEQ_LENGTH_HOURS
 
 logger = logging.getLogger(__name__)
 

--- a/src/slices/debug/snapshots.py
+++ b/src/slices/debug/snapshots.py
@@ -14,12 +14,12 @@ import numpy as np
 import polars as pl
 import yaml
 
-from slices.constants import SEQ_LENGTH_HOURS
-
 # Import the canonical PipelineStage from staged_snapshots
 # This module previously had its own PipelineStage with different stage names.
 # For backwards compatibility, we keep the old stage names as aliases.
 from .staged_snapshots import PipelineStage
+
+from slices.constants import SEQ_LENGTH_HOURS
 
 
 class LegacyPipelineStage(str, Enum):

--- a/src/slices/models/encoders/linear.py
+++ b/src/slices/models/encoders/linear.py
@@ -11,9 +11,9 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from slices.models.common import apply_pooling
-
 from .base import BaseEncoder, EncoderConfig
+
+from slices.models.common import apply_pooling
 
 
 @dataclass

--- a/src/slices/models/encoders/observation.py
+++ b/src/slices/models/encoders/observation.py
@@ -18,10 +18,10 @@ from typing import Any, Dict, Optional, Tuple
 import torch
 import torch.nn as nn
 
-from slices.models.common import apply_pooling
-
 from .base import BaseEncoder, EncoderConfig
 from .transformer import TransformerEncoderLayer
+
+from slices.models.common import apply_pooling
 
 
 @dataclass

--- a/src/slices/models/encoders/smart.py
+++ b/src/slices/models/encoders/smart.py
@@ -17,9 +17,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from slices.models.common import PositionalEncoding
-
 from .base import BaseEncoder, EncoderConfig
+
+from slices.models.common import PositionalEncoding
 
 
 @dataclass

--- a/src/slices/models/encoders/transformer.py
+++ b/src/slices/models/encoders/transformer.py
@@ -10,14 +10,14 @@ from typing import Any, Dict, Optional, Tuple
 import torch
 import torch.nn as nn
 
+from .base import BaseEncoder, EncoderConfig
+
 from slices.models.common import (
     PositionalEncoding,
     apply_pooling,
     build_sinusoidal_pe,
     get_activation,
 )
-
-from .base import BaseEncoder, EncoderConfig
 
 
 @dataclass

--- a/src/slices/models/heads/mlp.py
+++ b/src/slices/models/heads/mlp.py
@@ -9,9 +9,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from slices.models.common import get_activation
-
 from .base import BaseTaskHead, TaskHeadConfig
+
+from slices.models.common import get_activation
 
 
 class MLPTaskHead(BaseTaskHead):

--- a/src/slices/models/pretraining/jepa.py
+++ b/src/slices/models/pretraining/jepa.py
@@ -23,8 +23,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from slices.models.common import build_sinusoidal_pe
-
 from .base import BaseSSLObjective, SSLConfig, require_ssl_tokenizing_encoder
 from .masking import (
     create_block_timestep_mask,
@@ -32,6 +30,8 @@ from .masking import (
     extract_visible_timesteps,
     scatter_visible_timesteps,
 )
+
+from slices.models.common import build_sinusoidal_pe
 
 
 @dataclass

--- a/src/slices/models/pretraining/mae.py
+++ b/src/slices/models/pretraining/mae.py
@@ -17,10 +17,10 @@ from typing import Dict, Tuple
 import torch
 import torch.nn as nn
 
-from slices.models.common import build_sinusoidal_pe
-
 from .base import BaseSSLObjective, SSLConfig, require_ssl_tokenizing_encoder
 from .masking import create_timestep_mask, extract_visible_timesteps, scatter_visible_timesteps
+
+from slices.models.common import build_sinusoidal_pe
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- organize imports flagged by CI ruff checks

## Verification
- uv run ruff check src scripts tests --no-cache
- uv run mypy src
- uv run pytest -q